### PR TITLE
Fix component lifecycle hooks

### DIFF
--- a/addon/components/user-media-src.js
+++ b/addon/components/user-media-src.js
@@ -38,10 +38,10 @@ export default Ember.Component.extend({
 
 	_startup: function () {
 		this._startStream();
-	}.on('willInsertElement'),
+	}.on('didInsertElement'),
 
 	_shutdown: function () {
 		this._stopStream();
-	}.on('didDestroyElement')
+	}.on('willDestroyElement')
 
 });


### PR DESCRIPTION
1. There is no such hook like `didDestroyElement` (but there is
   `willDestroyElement`)
2. Changed `willInsertElement` to `didInsertElement`, as capturing media only
   makes sense in an already inserted element.